### PR TITLE
feat: add decrement function to counter store

### DIFF
--- a/src/stores/__tests__/counter.spec.ts
+++ b/src/stores/__tests__/counter.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useCounterStore } from '../counter'
+
+describe('Counter Store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('increments the count', () => {
+    const counter = useCounterStore()
+    expect(counter.count).toBe(0)
+    counter.increment()
+    expect(counter.count).toBe(1)
+  })
+
+  it('decrements the count', () => {
+    const counter = useCounterStore()
+    expect(counter.count).toBe(0)
+    counter.decrement()
+    expect(counter.count).toBe(-1)
+  })
+})

--- a/src/stores/counter.ts
+++ b/src/stores/counter.ts
@@ -8,5 +8,9 @@ export const useCounterStore = defineStore('counter', () => {
     count.value++
   }
 
-  return { count, doubleCount, increment }
+  function decrement() {
+    count.value--
+  }
+
+  return { count, doubleCount, increment, decrement }
 })


### PR DESCRIPTION
Adds a `decrement` function to the `counter` store to allow for decreasing the count.

Also adds a new test suite for the counter store, including tests for both the `increment` and `decrement` functions.