### PR TITLE
Bump @vitest/eslint-plugin and ossf/scorecard-action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -38,7 +38,7 @@ jobs:
           persist-credentials: false
 
       - name: 'Run analysis'
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        uses: ossf/scorecard-action@2d1146689b9bda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/node": "26.1.1",
         "@vitejs/plugin-vue": "6.0.8",
         "@vitejs/plugin-vue-jsx": "5.1.6",
-        "@vitest/eslint-plugin": "1.6.23",
+        "@vitest/eslint-plugin": "1.6.24",
         "@vue/eslint-config-prettier": "10.2.0",
         "@vue/eslint-config-typescript": "14.9.0",
         "@vue/test-utils": "2.4.11",
@@ -2075,9 +2075,9 @@
       }
     },
     "node_modules/@vitest/eslint-plugin": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.23.tgz",
-      "integrity": "sha512-CbrXxQpIUMbeyylGlxaxTgnWYM44et4Nx58swl7+vrTyC9Ttx+hQoy8BGCregbbZ08K5qFhRHeoad1VvERUbkg==",
+      "version": "1.6.24",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.24.tgz",
+      "integrity": "sha512-U5isuChJ58H1M6oRGaIotYbH2gM1rhzKUjtiarqpLNG/3+fzXIXs5RyTLrYQJmQPnXbvIMPFvI9z8ufpFZc8lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/node": "26.1.1",
     "@vitejs/plugin-vue": "6.0.8",
     "@vitejs/plugin-vue-jsx": "5.1.6",
-    "@vitest/eslint-plugin": "1.6.23",
+    "@vitest/eslint-plugin": "1.6.24",
     "@vue/eslint-config-prettier": "10.2.0",
     "@vue/eslint-config-typescript": "14.9.0",
     "@vue/test-utils": "2.4.11",


### PR DESCRIPTION
## Summary
Follow-up to #45 — new package/action releases landed since that PR merged.

- Bumps `@vitest/eslint-plugin` 1.6.23→1.6.24.
- Bumps `ossf/scorecard-action` v2.4.3→v2.4.4, pinned by full commit SHA as before.
- `typescript` stays pinned at 6.0.3 — 7.0.2 still breaks `vue-tsc` with `ERR_PACKAGE_PATH_NOT_EXPORTED`.
- All other npm packages and GitHub Actions were already at their latest release.

## Test plan
- [x] `npm run type-check`
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npx vitest run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)