### PR TITLE
Fix security findings: CI hardening, CVE remediation, and CSP

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,8 +8,7 @@
       "Bash(curl -s https://api.github.com/repos/actions/setup-node/releases/latest)",
       "Bash(curl -s https://api.github.com/repos/github/codeql-action/releases/latest)",
       "Bash(curl -s https://api.github.com/repos/Azure/static-web-apps-deploy/releases/latest)",
-      "Bash(curl -s https://api.github.com/repos/github/codeql-action/releases)",
-      "Bash(python3)"
+      "Bash(curl -s https://api.github.com/repos/github/codeql-action/releases)"
     ]
   }
 }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,13 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build
         run: npm run build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,6 +58,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/package-lock.json
+++ b/package-lock.json
@@ -3214,9 +3214,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3358,16 +3358,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4065,23 +4065,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/editorconfig/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/editorconfig/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/editorconfig/node_modules/commander": {
@@ -5027,23 +5010,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
@@ -7499,9 +7465,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7953,9 +7919,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.31.6",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.6.tgz",
-      "integrity": "sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA==",
+      "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.33.1.tgz",
+      "integrity": "sha512-DEN6ICHk3Tk0Uf/hrAHh7xlt7iL5CJFBtPZinA0H62DrGG/KPKqq/Nzj6lCXPS4Ay/sf/14zNnk9LpqKzBIc+w==",
       "dev": true,
       "license": "MIT",
       "os": [
@@ -7972,7 +7938,7 @@
         "systeminformation": "lib/cli.js"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=10.0.0"
       },
       "funding": {
         "type": "Buy me a coffee",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "lint": "run-s lint:*",
     "format": "prettier --write src/"
   },
+  "overrides": {
+    "brace-expansion": "5.0.8"
+  },
   "dependencies": {
     "pinia": "4.0.2",
     "vue": "3.5.40",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,50 @@
 import { fileURLToPath, URL } from 'node:url'
 
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueJsx from '@vitejs/plugin-vue-jsx'
 import vueDevTools from 'vite-plugin-vue-devtools'
+
+// The production bundle loads only same-origin scripts and styles, so 'self' is
+// sufficient everywhere. `data:` is needed for images because Vite inlines small
+// assets (the logo) as data URIs.
+//
+// Applied at build time only: the dev server relies on inline scripts and a
+// websocket for HMR, which this policy would block.
+//
+// Note `frame-ancestors` is deliberately absent — browsers ignore it in a meta
+// tag. Set it (or X-Frame-Options) as a response header at the CDN/host to
+// prevent clickjacking.
+const csp = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self'",
+  "img-src 'self' data:",
+  "font-src 'self'",
+  "connect-src 'self'",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+].join('; ')
+
+function cspPlugin(): Plugin {
+  return {
+    name: 'inject-csp',
+    apply: 'build',
+    transformIndexHtml(html) {
+      return {
+        html,
+        tags: [
+          {
+            tag: 'meta',
+            attrs: { 'http-equiv': 'Content-Security-Policy', content: csp },
+            injectTo: 'head-prepend',
+          },
+        ],
+      }
+    },
+  }
+}
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -11,6 +52,7 @@ export default defineConfig({
     vue(),
     vueJsx(),
     vueDevTools(),
+    cspPlugin(),
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
Follow-up to the security review of this codebase. Fixes all five findings:

- **CI supply chain**: `build.yaml` now uses `npm ci` instead of `npm install`, so builds install the lockfile exactly instead of potentially resolving away from the pinned versions. Added `persist-credentials: false` to `actions/checkout` in `build.yaml` and `codeql.yml` (matching what `scorecard.yml` already did), so `GITHUB_TOKEN` isn't left on disk while `npm ci` runs postinstall scripts from ~600 packages.
- **Dependency CVEs**: `npm audit` now reports 0 vulnerabilities (down from 4 high, all dev-only). `axios`, `shell-quote`, and `systeminformation` were cleared by `npm audit fix`. `brace-expansion` needed a manual `overrides` pin to `5.0.8` instead — npm's suggested `--force` fix would have downgraded `@vue/test-utils` 2.4.11→2.4.0 to patch a DoS, and the advisory's only real patched release is 5.0.8 (no 2.x backport). 5.0.8 is dual-published ESM+CJS, which is what minimatch consumes, so it dedupes cleanly with no downgrade.
- **Content-Security-Policy**: injected into the built `index.html` via a build-only Vite plugin (not a static tag, since the dev server needs inline scripts + a websocket for HMR, which the policy would block). Verified in a real headless Chromium against the production build — the app mounts and fires zero CSP violations. Confirmed the dev server still serves CSP-free HTML.
- **Agent config**: dropped the blanket `Bash(python3)` allow rule from the tracked `.claude/settings.json`, which auto-approved arbitrary Python execution for anyone who clones the repo.

## Test plan
- [x] `npm run type-check`
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npx vitest run`
- [x] `npm ci` from a clean state (what CI now runs)
- [x] `npm audit` → 0 vulnerabilities
- [x] Production build tested in real headless Chromium: app mounts, zero CSP violations
- [x] Dev server confirmed to still serve HTML without the CSP (HMR unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)