### PR TITLE
fix(deps): bump transitive undici 7.28.0 -> 7.29.0 (5 alerts)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8257,9 +8257,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

Fixes Dependabot alerts **#96, #97, #98, #99, #100** — all on `undici`, `< 7.29.0`, in `package-lock.json`, **dev scope** (jsdom -> vitest test environment; not shipped in the production bundle).

| Alert | Severity | Advisory | CVE |
|---|---|---|---|
| #97 | **high** | [GHSA-4cwx-7wf7-3272](https://github.com/advisories/GHSA-4cwx-7wf7-3272) | CVE-2026-13697 |
| #96 | medium | [GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524) | CVE-2026-16728 |
| #99 | medium | [GHSA-v3r7-h72x-cjcm](https://github.com/advisories/GHSA-v3r7-h72x-cjcm) | CVE-2026-16729 |
| #98 | medium | [GHSA-jr45-8vmc-qm54](https://github.com/advisories/GHSA-jr45-8vmc-qm54) | CVE-2026-14643 |
| #100 | medium | [GHSA-m8rv-5g2x-5cg5](https://github.com/advisories/GHSA-m8rv-5g2x-5cg5) | CVE-2026-15157 |

## Change

`undici` `7.28.0 -> 7.29.0` (cooloff-cleared, published 2026-07-24, ~377h old at resolution time).

This is a **transitive** dependency, pulled in by `jsdom@29.1.1` (a devDependency used only by vitest's jsdom test environment). `jsdom` already declares `"undici": "^7.25.0"`, a range that admits the patched `7.29.0` — **no jsdom major bump is needed**. `npm update undici` regenerated `package-lock.json` to resolve the already-permitted patched version. `package.json` is untouched; `undici` is not added as a direct dependency.

No other lockfile entries changed as a side effect of this bump.

## Test plan

- [x] `npm run build` (type-check + vite build) — passes clean.
- [x] `npm run test:unit -- --run` — 4 pre-existing test failures reproduced identically on `master` before this change (caused by an unrelated stray untracked worktree directory `.claude/worktrees/update-dependencies-pin-sha-dec89c` that vitest picks up); this PR introduces no new test failures. A reviewer may want to clean up that stray worktree directory separately, but it is out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)